### PR TITLE
Fixed Progress-/Speed-/ETA-indication for yt-dlp

### DIFF
--- a/modules/download/DownloadQuery.js
+++ b/modules/download/DownloadQuery.js
@@ -172,13 +172,13 @@ class DownloadQuery extends Query {
                 let liveDataArray = liveData.split(" ").filter((el) => {
                     return el !== ""
                 });
-                if (liveDataArray.length > 10) return;
+                if (liveDataArray.length > 12) return;
                 liveDataArray = liveDataArray.filter((el) => {
                     return el !== "\n"
                 });
                 let percentage = liveDataArray[1];
-                let speed = liveDataArray[5];
-                let eta = liveDataArray[7];
+                let speed = liveDataArray[6];
+                let eta = liveDataArray[8];
                 this.progressBar.updateDownload(percentage, eta, speed, this.video.audioOnly ? true : this.video.downloadingAudio);
             }));
         } catch (exception) {


### PR DESCRIPTION
Increased `liveDataArray.length` comparison on [_line 175_](https://github.com/yymirror/youtube-dl-gui/blob/3be67b4682fdb2c95d0a9d0f20c1ca8f416e2998/modules/download/DownloadQuery.js#L175) to a value of `... > 12`.
Adjusted the following array-indices to reflect the correct values onto the GUI.