### PR TITLE
Allow download with duplicate filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.env
 /node_modules
 /.vs
+/binaries

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /.env
+/node_modules
+/.vs

--- a/modules/Filepaths.js
+++ b/modules/Filepaths.js
@@ -182,7 +182,7 @@ class Filepaths {
         try {
             fs.copyFileSync(fromFile, toFile);
         } catch (e) {
-            console.error("Could not copy " + filename + " to " + to + ".");
+            console.error("Could not copy " + filename + " to " + to + " : " + e);
         }
     }
 }

--- a/modules/Filepaths.js
+++ b/modules/Filepaths.js
@@ -202,20 +202,21 @@ class Filepaths {
     IndexFileIfAlreadyExists(filePath)
     {
         let newFilePath = filePath;
+
+        let splitPath = newFilePath.split('.');            
+        let fileExt = "";
+        let fileName = newFilePath;
+        
+        if(splitPath.length > 1)
+        {
+            fileExt = "." + splitPath[splitPath.length - 1]
+            fileName = fileName.replace(fileExt, "");
+        }
+
         let index = 0;
 
         while(fs.existsSync(newFilePath))
         {
-            let splitPath = newFilePath.split('.');            
-            let fileExt = "";
-            let fileName = newFilePath;
-
-            if(splitPath.length > 1)
-            {
-               fileExt = "." + splitPath[splitPath.length - 1]
-               fileName = fileName.replace(fileExt, "");
-            }
-
             index = index + 1;         
             newFilePath = fileName + "(" + index + ")" + fileExt;
         }

--- a/modules/Filepaths.js
+++ b/modules/Filepaths.js
@@ -188,12 +188,39 @@ class Filepaths {
 
     moveFile(from, to, filename) {
         const fromFile = path.join(from, filename);
-        const toFile = path.join(to, filename);
+        let toFile = path.join(to, filename);
+
+        toFile = this.IndexFileIfAlreadyExists(toFile);
+
         try {
             fs.renameSync(fromFile, toFile);
         } catch (e) {
             console.error("Could not move " + filename + " to " + to + " : " + e);
         }
+    }
+
+    IndexFileIfAlreadyExists(filePath)
+    {
+        let newFilePath = filePath;
+        let index = 0;
+
+        while(fs.existsSync(newFilePath))
+        {
+            let splitPath = newFilePath.split('.');            
+            let fileExt = "";
+            let fileName = newFilePath;
+
+            if(splitPath.length > 1)
+            {
+               fileExt = "." + splitPath[splitPath.length - 1]
+               fileName = fileName.replace(fileExt, "");
+            }
+
+            index = index + 1;         
+            newFilePath = fileName + "(" + index + ")" + fileExt;
+        }
+
+        return newFilePath;
     }
 }
 

--- a/modules/Filepaths.js
+++ b/modules/Filepaths.js
@@ -185,6 +185,16 @@ class Filepaths {
             console.error("Could not copy " + filename + " to " + to + " : " + e);
         }
     }
+
+    moveFile(from, to, filename) {
+        const fromFile = path.join(from, filename);
+        const toFile = path.join(to, filename);
+        try {
+            fs.renameSync(fromFile, toFile);
+        } catch (e) {
+            console.error("Could not move " + filename + " to " + to + " : " + e);
+        }
+    }
 }
 
 module.exports = Filepaths;

--- a/modules/download/DownloadQuery.js
+++ b/modules/download/DownloadQuery.js
@@ -26,7 +26,6 @@ class DownloadQuery extends Query {
         let output = path.join(tempFolderPath, Utils.resolvePlaylistPlaceholders(this.environment.settings.nameFormat, this.playlistMeta));
           
         let args = [];
-     
         if(this.video.audioOnly) {
             let audioQuality = this.video.audioQuality;
             if(audioQuality === "best") {
@@ -175,10 +174,7 @@ class DownloadQuery extends Query {
                     this.progressBar.reset();
                 }
                 
-                if (liveData.includes("Destination"))
-                { 
-                    destinationCount += 1;
-                }
+                if (liveData.includes("Destination")) destinationCount += 1;
 
                 if (destinationCount > 1) {
                     if (destinationCount === 2 && !this.video.audioOnly && !this.video.downloadingAudio) {

--- a/modules/download/DownloadQuery.js
+++ b/modules/download/DownloadQuery.js
@@ -21,10 +21,9 @@ class DownloadQuery extends Query {
 
     async connect() {
 
-        let videoID = this.url.replace("https://www.youtube.com/watch?v=", "");
-
-        let tempFolder = this.environment.settings.downloadPath + "/temp[" + videoID + "]";
-        let output = path.join(tempFolder, Utils.resolvePlaylistPlaceholders(this.environment.settings.nameFormat, this.playlistMeta));
+        let tempFolderName = "temp[" + this.identifier + "]";
+        let tempFolderPath = this.environment.settings.downloadPath + "/" + tempFolderName;
+        let output = path.join(tempFolderPath, Utils.resolvePlaylistPlaceholders(this.environment.settings.nameFormat, this.playlistMeta));
           
         let args = [];
      
@@ -146,6 +145,9 @@ class DownloadQuery extends Query {
             args.push(this.environment.settings.sponsorblockRemove);
         }
         if(this.environment.settings.keepUnmerged) args.push('--keep-video');
+
+        args.push('-k');
+
         let destinationCount = 0;
         let initialReset = false;
         let result = null;
@@ -201,13 +203,14 @@ class DownloadQuery extends Query {
             return exception;
         }
 
-        this.video.downloadedPath = tempFolder; 
+        this.video.downloadedPath = tempFolderPath; 
 
         if(this.video.audioOnly) {
             await this.removeThumbnail(".jpg");
         }
 
         this.environment.paths.moveFile(this.video.downloadedPath, this.environment.settings.downloadPath, this.video.filename);
+        this.RemoveTempFolder(tempFolderPath, tempFolderName);
 
         return result;
     }
@@ -224,6 +227,21 @@ class DownloadQuery extends Query {
                 if(extension !== ".webp") {
                     await this.removeThumbnail(".webp");
                 }
+            }
+        }
+    }
+
+    RemoveTempFolder(folderPath, folderName) 
+    {
+        if(folderPath != null) 
+        {
+            try 
+            {
+                fs.rmdirSync(folderPath, {recursive : true, force : true});
+            } 
+            catch(e) 
+            {
+                console.log("No left-over Temp Folder found to remove. (" + folderName + ")")
             }
         }
     }

--- a/modules/download/DownloadQuery.js
+++ b/modules/download/DownloadQuery.js
@@ -26,8 +26,6 @@ class DownloadQuery extends Query {
         let VideoDataFolderName = this.video.getFilename() + "_Data";
         if(this.environment.settings.avoidFailingToSaveDuplicateFileName)
             VideoDataFolderName += "[" + this.video.identifier + "]";
-        else
-            VideoDataFolderName += "[" + this.video.GetURLID() + "]";
 
         let VideoDataFolderPath = this.environment.settings.downloadPath + "/" + VideoDataFolderName;
         let output = path.join(VideoDataFolderPath, Utils.resolvePlaylistPlaceholders(this.environment.settings.nameFormat, this.playlistMeta));

--- a/modules/download/DownloadQuery.js
+++ b/modules/download/DownloadQuery.js
@@ -207,8 +207,6 @@ class DownloadQuery extends Query {
             await this.removeThumbnail(".jpg");
         }
 
-        //console.log(this.video.filename);
-
         this.environment.paths.moveFile(this.video.downloadedPath, this.environment.settings.downloadPath, this.video.filename);
 
         return result;

--- a/modules/persistence/Settings.js
+++ b/modules/persistence/Settings.js
@@ -9,7 +9,7 @@ class Settings {
         validateCertificate, enableEncoding, taskList, nameFormat, nameFormatMode,
         sizeMode, splitMode, maxConcurrent, updateBinary, downloadType, updateApplication, cookiePath,
         statSend, sponsorblockMark, sponsorblockRemove, sponsorblockApi, downloadMetadata, downloadJsonMetadata,
-        downloadThumbnail, keepUnmerged, calculateTotalSize, theme
+        downloadThumbnail, keepUnmerged, avoidFailingToSaveDuplicateFileName, calculateTotalSize, theme
     ) {
         this.paths = paths;
         this.env = env
@@ -34,6 +34,7 @@ class Settings {
         this.downloadJsonMetadata = downloadJsonMetadata == null ? false : downloadJsonMetadata;
         this.downloadThumbnail = downloadThumbnail == null ? false : downloadThumbnail;
         this.keepUnmerged = keepUnmerged == null ? false : keepUnmerged;
+        this.avoidFailingToSaveDuplicateFileName = avoidFailingToSaveDuplicateFileName == null ? false : avoidFailingToSaveDuplicateFileName;
         this.calculateTotalSize = calculateTotalSize == null ? true : calculateTotalSize;
         this.sizeMode = sizeMode == null ? "click" : sizeMode;
         this.splitMode = splitMode == null? "49" : splitMode;
@@ -94,6 +95,7 @@ class Settings {
                 data.downloadJsonMetadata,
                 data.downloadThumbnail,
                 data.keepUnmerged,
+                data.avoidFailingToSaveDuplicateFileName,
                 data.calculateTotalSize,
                 data.theme
             );
@@ -127,6 +129,7 @@ class Settings {
         this.downloadJsonMetadata = settings.downloadJsonMetadata;
         this.downloadThumbnail = settings.downloadThumbnail;
         this.keepUnmerged = settings.keepUnmerged;
+        this.avoidFailingToSaveDuplicateFileName = settings.avoidFailingToSaveDuplicateFileName;
         this.calculateTotalSize = settings.calculateTotalSize;
         this.sizeMode = settings.sizeMode;
         this.splitMode = settings.splitMode;
@@ -177,6 +180,7 @@ class Settings {
             downloadJsonMetadata: this.downloadJsonMetadata,
             downloadThumbnail: this.downloadThumbnail,
             keepUnmerged: this.keepUnmerged,
+            avoidFailingToSaveDuplicateFileName: this.avoidFailingToSaveDuplicateFileName,
             calculateTotalSize: this.calculateTotalSize,
             theme: this.theme,
             version: this.env.version

--- a/modules/types/Video.js
+++ b/modules/types/Video.js
@@ -148,10 +148,5 @@ class Video {
             }
         }
     }
-
-    GetURLID()
-    {
-        return this.url.replace("https://www.youtube.com/watch?v=", "");
-    }   
 }
 module.exports = Video;

--- a/modules/types/Video.js
+++ b/modules/types/Video.js
@@ -29,7 +29,6 @@ class Video {
             this.filename = path.basename(replaced);
         } 
 
-
         else if(liveData.includes("[ffmpeg] Merging formats into \""))
         {
             const noPrefix = liveData.replace("[ffmpeg] Merging formats into \"", "");
@@ -40,7 +39,6 @@ class Video {
             const noPrefix = liveData.replace("[ffmpeg] Adding metadata to '", "");
             this.filename = path.basename(noPrefix.trim().slice(0, -1));
         } 
-
 
         else if(liveData.includes("[Merger] Merging formats into \""))
         {
@@ -53,7 +51,6 @@ class Video {
             this.filename = path.basename(replaced);
         }
 
-        
         else if(liveData.includes("[Metadata] Adding metadata to '"))
         {
             const noPrefix = liveData.replace("[Metadata] Adding metadata to '", "");

--- a/modules/types/Video.js
+++ b/modules/types/Video.js
@@ -32,6 +32,9 @@ class Video {
         } else if(liveData.includes("[ffmpeg] Adding metadata to '")) {
             const noPrefix = liveData.replace("[ffmpeg] Adding metadata to '", "");
             this.filename = path.basename(noPrefix.trim().slice(0, -1));
+        } else if(liveData.includes("[ExtractAudio] Destination: ")) {
+            const replaced = liveData.replace("[ExtractAudio] Destination: ", "");
+            this.filename = path.basename(replaced);
         }
     }
 

--- a/modules/types/Video.js
+++ b/modules/types/Video.js
@@ -28,6 +28,8 @@ class Video {
             const replaced = liveData.replace("[download] Destination: ", "");
             this.filename = path.basename(replaced);
         } 
+
+
         else if(liveData.includes("[ffmpeg] Merging formats into \""))
         {
             const noPrefix = liveData.replace("[ffmpeg] Merging formats into \"", "");
@@ -38,14 +40,11 @@ class Video {
             const noPrefix = liveData.replace("[ffmpeg] Adding metadata to '", "");
             this.filename = path.basename(noPrefix.trim().slice(0, -1));
         } 
+
+
         else if(liveData.includes("[Merger] Merging formats into \""))
         {
             const noPrefix = liveData.replace("[Merger] Merging formats into \"", "");
-            this.filename = path.basename(noPrefix.trim().slice(0, -1));
-        } 
-        else if(liveData.includes("[Metadata] Adding metadata to '"))
-        {
-            const noPrefix = liveData.replace("[Metadata] Adding metadata to '", "");
             this.filename = path.basename(noPrefix.trim().slice(0, -1));
         } 
         else if(liveData.includes("[ExtractAudio] Destination: ")) 
@@ -53,6 +52,13 @@ class Video {
             const replaced = liveData.replace("[ExtractAudio] Destination: ", "");
             this.filename = path.basename(replaced);
         }
+
+        
+        else if(liveData.includes("[Metadata] Adding metadata to '"))
+        {
+            const noPrefix = liveData.replace("[Metadata] Adding metadata to '", "");
+            this.filename = path.basename(noPrefix.trim().slice(0, -1));
+        } 
     }
 
     getFilename() {

--- a/modules/types/Video.js
+++ b/modules/types/Video.js
@@ -48,11 +48,6 @@ class Video {
             const noPrefix = liveData.replace("[Metadata] Adding metadata to '", "");
             this.filename = path.basename(noPrefix.trim().slice(0, -1));
         } 
-        else if(liveData.includes("[ExtractAudio] Destination: ")) 
-        {
-            const replaced = liveData.replace("[ExtractAudio] Destination: ", "");
-            this.filename = path.basename(replaced);
-        }
     }
 
     getFilename() {

--- a/modules/types/Video.js
+++ b/modules/types/Video.js
@@ -148,5 +148,10 @@ class Video {
             }
         }
     }
+
+    GetURLID()
+    {
+        return this.url.replace("https://www.youtube.com/watch?v=", "");
+    }   
 }
 module.exports = Video;

--- a/modules/types/Video.js
+++ b/modules/types/Video.js
@@ -23,16 +23,33 @@ class Video {
     }
 
     setFilename(liveData) {
-        if(liveData.includes("[download] Destination: ")) {
+        if(liveData.includes("[download] Destination: "))
+        {
             const replaced = liveData.replace("[download] Destination: ", "");
             this.filename = path.basename(replaced);
-        } else if(liveData.includes("[ffmpeg] Merging formats into \"")) {
+        } 
+        else if(liveData.includes("[ffmpeg] Merging formats into \""))
+        {
             const noPrefix = liveData.replace("[ffmpeg] Merging formats into \"", "");
             this.filename = path.basename(noPrefix.trim().slice(0, -1));
-        } else if(liveData.includes("[ffmpeg] Adding metadata to '")) {
+        } 
+        else if(liveData.includes("[ffmpeg] Adding metadata to '"))
+        {
             const noPrefix = liveData.replace("[ffmpeg] Adding metadata to '", "");
             this.filename = path.basename(noPrefix.trim().slice(0, -1));
-        } else if(liveData.includes("[ExtractAudio] Destination: ")) {
+        } 
+        else if(liveData.includes("[Merger] Merging formats into \""))
+        {
+            const noPrefix = liveData.replace("[Merger] Merging formats into \"", "");
+            this.filename = path.basename(noPrefix.trim().slice(0, -1));
+        } 
+        else if(liveData.includes("[Metadata] Adding metadata to '"))
+        {
+            const noPrefix = liveData.replace("[Metadata] Adding metadata to '", "");
+            this.filename = path.basename(noPrefix.trim().slice(0, -1));
+        } 
+        else if(liveData.includes("[ExtractAudio] Destination: ")) 
+        {
             const replaced = liveData.replace("[ExtractAudio] Destination: ", "");
             this.filename = path.basename(replaced);
         }

--- a/modules/types/Video.js
+++ b/modules/types/Video.js
@@ -48,6 +48,11 @@ class Video {
             const noPrefix = liveData.replace("[Metadata] Adding metadata to '", "");
             this.filename = path.basename(noPrefix.trim().slice(0, -1));
         } 
+        else if(liveData.includes("[ExtractAudio] Destination: ")) 
+        {
+            const replaced = liveData.replace("[ExtractAudio] Destination: ", "");
+            this.filename = path.basename(replaced);
+        }
     }
 
     getFilename() {

--- a/renderer/renderer.html
+++ b/renderer/renderer.html
@@ -385,6 +385,10 @@
                     <input class="check-input" type="checkbox" value="" id="keepUnmerged">
                     <label class="check-label" for="keepUnmerged">Keep unmerged files</label>
                 </div>
+                <div class="mb-1">
+                    <input class="check-input" type="checkbox" value="" id="avoidFailingToSaveDuplicateFileName">
+                    <label class="check-label" for="avoidFailingToSaveDuplicateFileName">Avoid failing to save duplicate filename</label>
+                </div>
                 <hr/>
                 <h3>Sponsorblock</h3>
                 <div class="mb-3">

--- a/renderer/renderer.html
+++ b/renderer/renderer.html
@@ -387,7 +387,7 @@
                 </div>
                 <div class="mb-1">
                     <input class="check-input" type="checkbox" value="" id="avoidFailingToSaveDuplicateFileName">
-                    <label class="check-label" for="avoidFailingToSaveDuplicateFileName">Avoid failing to save duplicate filename</label>
+                    <label class="check-label" for="avoidFailingToSaveDuplicateFileName" title="When the target filename already exists, enumerate the filename (e.g. 'filename (1).mp4').">Avoid failing to save duplicate filename</label>
                 </div>
                 <hr/>
                 <h3>Sponsorblock</h3>

--- a/renderer/renderer.html
+++ b/renderer/renderer.html
@@ -387,7 +387,7 @@
                 </div>
                 <div class="mb-1">
                     <input class="check-input" type="checkbox" value="" id="avoidFailingToSaveDuplicateFileName">
-                    <label class="check-label" for="avoidFailingToSaveDuplicateFileName" title="When the target filename already exists, enumerate the filename (e.g. 'filename(1).mp4').">Avoid failing to save duplicate filename</label>
+                    <label class="check-label" for="avoidFailingToSaveDuplicateFileName" title="When the target filename already exists, enumerate the filename (e.g. 'filename(1).mp4') at the cost of download resumability.">Avoid failing to save duplicate filename</label>
                 </div>
                 <hr/>
                 <h3>Sponsorblock</h3>

--- a/renderer/renderer.html
+++ b/renderer/renderer.html
@@ -387,7 +387,7 @@
                 </div>
                 <div class="mb-1">
                     <input class="check-input" type="checkbox" value="" id="avoidFailingToSaveDuplicateFileName">
-                    <label class="check-label" for="avoidFailingToSaveDuplicateFileName" title="When the target filename already exists, enumerate the filename (e.g. 'filename (1).mp4').">Avoid failing to save duplicate filename</label>
+                    <label class="check-label" for="avoidFailingToSaveDuplicateFileName" title="When the target filename already exists, enumerate the filename (e.g. 'filename(1).mp4').">Avoid failing to save duplicate filename</label>
                 </div>
                 <hr/>
                 <h3>Sponsorblock</h3>

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -1000,6 +1000,7 @@ async function getSettings() {
     $('#downloadJsonMetadata').prop('checked', settings.downloadJsonMetadata);
     $('#downloadThumbnail').prop('checked', settings.downloadThumbnail);
     $('#keepUnmerged').prop('checked', settings.keepUnmerged);
+    $('#avoidFailingToSaveDuplicateFileName').prop('checked', settings.avoidFailingToSaveDuplicateFileName);
     $('#calculateTotalSize').prop('checked', settings.calculateTotalSize);
     $('#maxConcurrent').val(settings.maxConcurrent);
     $('#concurrentLabel').html(`Max concurrent jobs <strong>(${settings.maxConcurrent})</strong>`);
@@ -1033,6 +1034,7 @@ function sendSettings() {
         downloadJsonMetadata: $('#downloadJsonMetadata').prop('checked'),
         downloadThumbnail: $('#downloadThumbnail').prop('checked'),
         keepUnmerged: $('#keepUnmerged').prop('checked'),
+        avoidFailingToSaveDuplicateFileName: $('#avoidFailingToSaveDuplicateFileName').prop('checked'),
         calculateTotalSize: $('#calculateTotalSize').prop('checked'),
         sizeMode: $('#sizeSetting').val(),
         splitMode: $('#splitMode').val(),


### PR DESCRIPTION
PR Fixes files not being saved when a file with the same name exists in the download folder.

It is fixed by creating a new temp folder (named by the unique identifier) in the download folder for each video.

Then all the embedding and processing are done in this folder and once done, the final file (be it mp4, opus, or whatever the user has requested) will be moved out of the temp folder.

While moving it out, it checks for any pre-existing file with the same name, and if it exists, it adds "(n)" to the file name where n represents the duplicate file name count.

After Moving the processed file, the temp folder is forced Deleted.