### PR TITLE
Small additions

### DIFF
--- a/modules/DoneAction.js
+++ b/modules/DoneAction.js
@@ -5,7 +5,7 @@ const actions = {
         "Sleep": ["rundll32.exe", "powrprof.dll,SetSuspendState", "0,1,0"],
         "Lock": ["rundll32.exe", "user32.dll,LockWorkStation"],
         "Shutdown": ["shutdown", "/s", "/f", "/t", "0"],
-        "Hibernate": ["shutdown", "/h", "/f", "/t", "0"],
+        "Hibernate (if enabled)": ["shutdown", "/h", "/f", "/t", "0"],
         "Reboot": ["shutdown", "/r", "/f", "/t", "0"],
     },
     "linux": {

--- a/modules/DoneAction.js
+++ b/modules/DoneAction.js
@@ -5,6 +5,7 @@ const actions = {
         "Sleep": ["rundll32.exe", "powrprof.dll,SetSuspendState", "0,1,0"],
         "Lock": ["rundll32.exe", "user32.dll,LockWorkStation"],
         "Shutdown": ["shutdown", "/s", "/f", "/t", "0"],
+        "Hibernate": ["shutdown", "/h", "/f", "/t", "0"],
         "Reboot": ["shutdown", "/r", "/f", "/t", "0"],
     },
     "linux": {

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -36,6 +36,7 @@ async function init() {
     //Updates the placeholder to a copied link
     window.main.receive("updateLinkPlaceholder", (args) => {
         $('#add-url').prop("placeholder", args.text);
+        $('#add-url').focus();
         linkCopied = args.copied;
     });
 

--- a/tests/DoneAction.test.js
+++ b/tests/DoneAction.test.js
@@ -5,7 +5,7 @@ jest.mock('execa');
 
 const platforms = ["win32", "linux", "darwin"];
 const actions = ["Lock", "Sleep", "Shutdown"];
-const actionLength = [4, 3, 3];
+const actionLength = [5, 3, 3];
 
 beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
These are minor changes I had in my fork. 

I noticed today that this fork is active, so I'm rebasing my changes on top of it
I deleted all my fixes as I think you already did all of them more correctly (ytl-dlp download paths and progress reporting etc..)

Two changes appear in this PR

adding option for hibernate when done (On windows)
and the second is to focus the input field on startup. I think it's a reasonable behavior