### PR TITLE
QOL added link to version number

### DIFF
--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -1011,7 +1011,7 @@ async function getSettings() {
     $('#sizeSetting').val(settings.sizeMode);
     $('#splitMode').val(settings.splitMode);
     $('#theme').val(settings.theme);
-    $('#version').html("<strong>Version: </strong>" + settings.version);
+    $('#version').html("<strong>Version: </strong><a href='https://github.com/StefanLobbenmeier/youtube-dl-gui/releases/tag/v" + settings.version + "' target='_blank'>" + settings.version + " &#128279;</a>");
     window.settings = settings;
 }
 


### PR DESCRIPTION
Little Quality Of Life. Let the user click the version number in preferences to open the release's info page. Handy to know what's the update is about, and also to get access to the current repo instead of the old dead one.

![image](https://github.com/user-attachments/assets/6fabf015-d001-48d7-b68b-0e899b7e87e1)
