### PR TITLE
Add filename sanitation

### DIFF
--- a/modules/download/DownloadQuery.js
+++ b/modules/download/DownloadQuery.js
@@ -137,6 +137,9 @@ class DownloadQuery extends Query {
         if(this.environment.settings.downloadMetadata) {
             args.push('--add-metadata');
         }
+        if(this.environment.settings.compatFilename) {
+            args.push('--restrict-filenames');
+        }
         if(this.environment.settings.downloadThumbnail) {
             args.push('--write-thumbnail');
         }

--- a/modules/persistence/Settings.js
+++ b/modules/persistence/Settings.js
@@ -8,7 +8,7 @@ class Settings {
         proxy, rateLimit, autoFillClipboard, noPlaylist, globalShortcut, userAgent,
         validateCertificate, enableEncoding, taskList, nameFormat, nameFormatMode,
         sizeMode, splitMode, maxConcurrent, retries, fileAccessRetries, updateBinary, downloadType, updateApplication, cookiePath,
-        statSend, sponsorblockMark, sponsorblockRemove, sponsorblockApi, downloadMetadata, downloadJsonMetadata,
+        statSend, sponsorblockMark, sponsorblockRemove, sponsorblockApi, downloadMetadata, downloadJsonMetadata, compatFilename,
         downloadThumbnail, keepUnmerged, avoidFailingToSaveDuplicateFileName, calculateTotalSize, theme
     ) {
         this.paths = paths;
@@ -32,6 +32,7 @@ class Settings {
         this.sponsorblockApi = sponsorblockApi == null ? "https://sponsor.ajay.app" : sponsorblockApi;
         this.downloadMetadata = downloadMetadata == null ? true : downloadMetadata;
         this.downloadJsonMetadata = downloadJsonMetadata == null ? false : downloadJsonMetadata;
+        this.downloadJsonMetadata = compatFilename == null ? false : compatFilename;
         this.downloadThumbnail = downloadThumbnail == null ? false : downloadThumbnail;
         this.keepUnmerged = keepUnmerged == null ? false : keepUnmerged;
         this.avoidFailingToSaveDuplicateFileName = avoidFailingToSaveDuplicateFileName == null ? false : avoidFailingToSaveDuplicateFileName;
@@ -97,6 +98,7 @@ class Settings {
                 data.sponsorblockApi,
                 data.downloadMetadata,
                 data.downloadJsonMetadata,
+                data.compatFilename,
                 data.downloadThumbnail,
                 data.keepUnmerged,
                 data.avoidFailingToSaveDuplicateFileName,
@@ -131,6 +133,7 @@ class Settings {
         this.sponsorblockApi = settings.sponsorblockApi;
         this.downloadMetadata = settings.downloadMetadata;
         this.downloadJsonMetadata = settings.downloadJsonMetadata;
+        this.compatFilename = settings.compatFilename;
         this.downloadThumbnail = settings.downloadThumbnail;
         this.keepUnmerged = settings.keepUnmerged;
         this.avoidFailingToSaveDuplicateFileName = settings.avoidFailingToSaveDuplicateFileName;
@@ -186,6 +189,7 @@ class Settings {
             sponsorblockApi: this.sponsorblockApi,
             downloadMetadata: this.downloadMetadata,
             downloadJsonMetadata: this.downloadJsonMetadata,
+            compatFilename: this.compatFilename,
             downloadThumbnail: this.downloadThumbnail,
             keepUnmerged: this.keepUnmerged,
             avoidFailingToSaveDuplicateFileName: this.avoidFailingToSaveDuplicateFileName,

--- a/renderer/renderer.html
+++ b/renderer/renderer.html
@@ -397,6 +397,10 @@
                     <label class="check-label" for="downloadJsonMetadata">Save JSON metadata</label>
                 </div>
                 <div class="mb-1">
+                    <input class="check-input" type="checkbox" value="" id="compatFilename">
+                    <label class="check-label" for="compatFilename">Sanitize filename</label>
+                </div>
+                <div class="mb-1">
                     <input class="check-input" type="checkbox" value="" id="downloadThumbnail">
                     <label class="check-label" for="downloadThumbnail">Save thumbnail as file</label>
                 </div>

--- a/renderer/renderer.js
+++ b/renderer/renderer.js
@@ -1000,6 +1000,7 @@ async function getSettings() {
     $('#sponsorblockApi').val(settings.sponsorblockApi);
     $('#downloadMetadata').prop('checked', settings.downloadMetadata);
     $('#downloadJsonMetadata').prop('checked', settings.downloadJsonMetadata);
+    $('#compatFilename').prop('checked', settings.compatFilename);
     $('#downloadThumbnail').prop('checked', settings.downloadThumbnail);
     $('#keepUnmerged').prop('checked', settings.keepUnmerged);
     $('#avoidFailingToSaveDuplicateFileName').prop('checked', settings.avoidFailingToSaveDuplicateFileName);
@@ -1036,6 +1037,7 @@ function sendSettings() {
         sponsorblockApi: $('#sponsorblockApi').val(),
         downloadMetadata: $('#downloadMetadata').prop('checked'),
         downloadJsonMetadata: $('#downloadJsonMetadata').prop('checked'),
+        compatFilename: $('#compatFilename').prop('checked'),
         downloadThumbnail: $('#downloadThumbnail').prop('checked'),
         keepUnmerged: $('#keepUnmerged').prop('checked'),
         avoidFailingToSaveDuplicateFileName: $('#avoidFailingToSaveDuplicateFileName').prop('checked'),


### PR DESCRIPTION
Implementation of a useful toggle from yt-dlp, makes filenames shell compatible & removes special characters like emojis. Also fixes some (very rare) download bugs related to filenames.